### PR TITLE
Force intermediate PNG files to use RGBA format

### DIFF
--- a/src/main/groovy/com/eowise/packer/Packer.groovy
+++ b/src/main/groovy/com/eowise/packer/Packer.groovy
@@ -111,6 +111,9 @@ class Packer extends DefaultTask {
                     actions {
                         -background('none')
                         inputFile()
+                        // Full-color RGB with alpha, to work around
+                        // https://github.com/libgdx/libgdx/issues/4814
+                        -define('png:color-type=6')
                         outputFile { fileName, extension -> "${fileName}.png" }
                     }
                 }
@@ -130,6 +133,9 @@ class Packer extends DefaultTask {
                             actions {
                                 inputFile()
                                 -resize(resolution.ratio * 100 + '%')
+                                // Full-color RGB with alpha, to work around
+                                // https://github.com/libgdx/libgdx/issues/4814
+                                -define('png:color-type=6')
                                 outputFile()
                             }
                         }


### PR DESCRIPTION
Without this, if an image only has some white and some fully transparent
pixels, ImageMagick will optimize it and trigger a bug in Java's ImageIO
class (used by LibGDX's TexturePacker), causing it to ignore the alpha
and replace transparent pixels by black.

An upstream fix in LibGDX is not trivial
(https://github.com/libgdx/libgdx/issues/4814) and a fix in Java itself
seems unlikely (http://bugs.java.com/view_bug.do?bug_id=6703368). Hence
this workaround.